### PR TITLE
#11 [feat] main / 프래그먼트 전환 구현

### DIFF
--- a/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
@@ -1,7 +1,26 @@
 package com.hous.hous_aos.ui.home
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.hous.hous_aos.databinding.FragmentHomeBinding
 
 class HomeFragment : Fragment() {
+    private var _binding: FragmentHomeBinding? = null
+    private val binding get() = _binding!!
 
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentHomeBinding.inflate(layoutInflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
@@ -1,4 +1,4 @@
-package com.hous.hous_aos
+package com.hous.hous_aos.ui.home
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/home/HomeFragment.kt
@@ -1,0 +1,7 @@
+package com.hous.hous_aos
+
+import androidx.fragment.app.Fragment
+
+class HomeFragment : Fragment() {
+
+}

--- a/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
@@ -4,8 +4,13 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.commit
+import androidx.fragment.app.replace
 import com.hous.hous_aos.R
 import com.hous.hous_aos.databinding.ActivityMainBinding
+import com.hous.hous_aos.ui.home.HomeFragment
+import com.hous.hous_aos.ui.profile.ProfileFragment
+import com.hous.hous_aos.ui.rules.RulesFragment
 
 class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
@@ -16,6 +21,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initBotNav() {
+        binding.botNavMain.selectedItemId = R.id.ic_bot_nav_home
+        supportFragmentManager.commit {
+            replace<HomeFragment>(R.id.fcv_main)
+        }
+
         binding.botNavMain.apply {
             setOnItemSelectedListener {
                 when (it.itemId) {
@@ -33,6 +43,11 @@ class MainActivity : AppCompatActivity() {
                             R.color.sel_bot_navi_home_color
                         )
                         binding.tvMainTitle.text = getString(R.string.home_title)
+                        supportFragmentManager.commit {
+                            replace<HomeFragment>(R.id.fcv_main)
+                            setReorderingAllowed(true)
+                            addToBackStack(null)
+                        }
                         true
                     }
                     R.id.ic_bot_nav_rules -> {
@@ -49,6 +64,11 @@ class MainActivity : AppCompatActivity() {
                             R.color.sel_bot_navi_rule_color
                         )
                         binding.tvMainTitle.text = getString(R.string.rules_title)
+                        supportFragmentManager.commit {
+                            replace<RulesFragment>(R.id.fcv_main)
+                            setReorderingAllowed(true)
+                            addToBackStack(null)
+                        }
                         true
                     }
                     else -> {
@@ -65,6 +85,11 @@ class MainActivity : AppCompatActivity() {
                             R.color.sel_bot_navi_profile_color
                         )
                         binding.tvMainTitle.text = getString(R.string.profile_title)
+                        supportFragmentManager.commit {
+                            replace<ProfileFragment>(R.id.fcv_main)
+                            setReorderingAllowed(true)
+                            addToBackStack(null)
+                        }
                         true
                     }
                 }

--- a/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
@@ -46,7 +46,6 @@ class MainActivity : AppCompatActivity() {
                         supportFragmentManager.commit {
                             replace<HomeFragment>(R.id.fcv_main)
                             setReorderingAllowed(true)
-                            addToBackStack(null)
                         }
                         true
                     }
@@ -67,7 +66,6 @@ class MainActivity : AppCompatActivity() {
                         supportFragmentManager.commit {
                             replace<RulesFragment>(R.id.fcv_main)
                             setReorderingAllowed(true)
-                            addToBackStack(null)
                         }
                         true
                     }
@@ -88,7 +86,6 @@ class MainActivity : AppCompatActivity() {
                         supportFragmentManager.commit {
                             replace<ProfileFragment>(R.id.fcv_main)
                             setReorderingAllowed(true)
-                            addToBackStack(null)
                         }
                         true
                     }

--- a/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
@@ -1,7 +1,26 @@
 package com.hous.hous_aos.ui.profile
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.hous.hous_aos.databinding.FragmentProfileBinding
 
 class ProfileFragment : Fragment() {
+    private var _binding: FragmentProfileBinding? = null
+    private val binding get() = _binding!!
 
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentProfileBinding.inflate(layoutInflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
@@ -1,0 +1,59 @@
+package com.hous.hous_aos
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [ProfileFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class ProfileFragment : Fragment() {
+    // TODO: Rename and change types of parameters
+    private var param1: String? = null
+    private var param2: String? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            param1 = it.getString(ARG_PARAM1)
+            param2 = it.getString(ARG_PARAM2)
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        return inflater.inflate(R.layout.fragment_profile, container, false)
+    }
+
+    companion object {
+        /**
+         * Use this factory method to create a new instance of
+         * this fragment using the provided parameters.
+         *
+         * @param param1 Parameter 1.
+         * @param param2 Parameter 2.
+         * @return A new instance of fragment ProfileFragment.
+         */
+        // TODO: Rename and change types and number of parameters
+        @JvmStatic
+        fun newInstance(param1: String, param2: String) =
+            ProfileFragment().apply {
+                arguments = Bundle().apply {
+                    putString(ARG_PARAM1, param1)
+                    putString(ARG_PARAM2, param2)
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/profile/ProfileFragment.kt
@@ -1,59 +1,7 @@
-package com.hous.hous_aos
+package com.hous.hous_aos.ui.profile
 
-import android.os.Bundle
 import androidx.fragment.app.Fragment
-import android.view.LayoutInflater
-import android.view.View
-import android.view.ViewGroup
 
-// TODO: Rename parameter arguments, choose names that match
-// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
-private const val ARG_PARAM1 = "param1"
-private const val ARG_PARAM2 = "param2"
-
-/**
- * A simple [Fragment] subclass.
- * Use the [ProfileFragment.newInstance] factory method to
- * create an instance of this fragment.
- */
 class ProfileFragment : Fragment() {
-    // TODO: Rename and change types of parameters
-    private var param1: String? = null
-    private var param2: String? = null
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            param1 = it.getString(ARG_PARAM1)
-            param2 = it.getString(ARG_PARAM2)
-        }
-    }
-
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_profile, container, false)
-    }
-
-    companion object {
-        /**
-         * Use this factory method to create a new instance of
-         * this fragment using the provided parameters.
-         *
-         * @param param1 Parameter 1.
-         * @param param2 Parameter 2.
-         * @return A new instance of fragment ProfileFragment.
-         */
-        // TODO: Rename and change types and number of parameters
-        @JvmStatic
-        fun newInstance(param1: String, param2: String) =
-            ProfileFragment().apply {
-                arguments = Bundle().apply {
-                    putString(ARG_PARAM1, param1)
-                    putString(ARG_PARAM2, param2)
-                }
-            }
-    }
 }

--- a/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
@@ -1,4 +1,4 @@
-package com.hous.hous_aos
+package com.hous.hous_aos.ui.rules
 
 import androidx.fragment.app.Fragment
 

--- a/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
@@ -1,0 +1,7 @@
+package com.hous.hous_aos
+
+import androidx.fragment.app.Fragment
+
+class RulesFragment : Fragment() {
+
+}

--- a/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/rules/RulesFragment.kt
@@ -1,7 +1,26 @@
 package com.hous.hous_aos.ui.rules
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.hous.hous_aos.databinding.FragmentRulesBinding
 
 class RulesFragment : Fragment() {
+    private var _binding: FragmentRulesBinding? = null
+    private val binding get() = _binding!!
 
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        _binding = FragmentRulesBinding.inflate(layoutInflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,6 +32,15 @@
                 android:textStyle="bold" />
         </androidx.appcompat.widget.Toolbar>
 
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fcv_main"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toTopOf="@+id/bot_nav_main"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tb_main" />
+
         <com.google.android.material.bottomnavigation.BottomNavigationView
             android:id="@+id/bot_nav_main"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".HomeFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -5,7 +5,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.home.HomeFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -3,12 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".HomeFragment">
+    tools:context=".ui.home.HomeFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:text="Home" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ProfileFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -5,7 +5,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.profile.ProfileFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -3,12 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ProfileFragment">
+    tools:context=".ui.profile.ProfileFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:text="Profile" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_rules.xml
+++ b/app/src/main/res/layout/fragment_rules.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".RulesFragment">
+
+    <!-- TODO: Update blank fragment layout -->
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="@string/hello_blank_fragment" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_rules.xml
+++ b/app/src/main/res/layout/fragment_rules.xml
@@ -5,7 +5,6 @@
     android:layout_height="match_parent"
     tools:context=".ui.rules.RulesFragment">
 
-    <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_rules.xml
+++ b/app/src/main/res/layout/fragment_rules.xml
@@ -3,12 +3,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".RulesFragment">
+    tools:context=".ui.rules.RulesFragment">
 
     <!-- TODO: Update blank fragment layout -->
     <TextView
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:text="@string/hello_blank_fragment" />
+        android:text="Rules" />
 
 </FrameLayout>


### PR DESCRIPTION
## 작업 사진

https://user-images.githubusercontent.com/84129098/178160079-d4c9be87-5249-4eed-b871-95c4ce07225f.mov

## 작업 개요

바텀내비게이션 클릭시 프래그먼트 전환 구현

## 작업 설명

- FragmentContainerView 생성
- Home, Rules, Profile 프래그먼트 생성 & 데이터바인딩
- `supportFragmentManager.commit { replace<HomeFragment>(R.id.fcv_main)}`를 이용하여 프래그먼트 전환
- `setReorderingAllowed(true)`를 호출하여 프래그먼트 전환 최적화
&nbsp; 관련 공식문서 : https://developer.android.com/guide/fragments/fragmentmanager

## 궁금한점

- x

## 어려웠던점

- `supportFragmentManager.commit` 사용하는 방법을 배웠다.
