### PR TITLE
#150 [feat] 중복 클릭 효과 제거

### DIFF
--- a/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
@@ -108,6 +108,13 @@ class MainActivity : AppCompatActivity() {
                     }
                 }
             }
+            setOnItemReselectedListener { menuItem ->
+                when (menuItem.itemId) {
+                    R.id.ic_bot_nav_home -> {}
+                    R.id.ic_bot_nav_rules -> {}
+                    else -> {}
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/hous/hous_aos/ui/main/MainActivity.kt
@@ -110,9 +110,9 @@ class MainActivity : AppCompatActivity() {
             }
             setOnItemReselectedListener { menuItem ->
                 when (menuItem.itemId) {
-                    R.id.ic_bot_nav_home -> {}
-                    R.id.ic_bot_nav_rules -> {}
-                    else -> {}
+                    R.id.ic_bot_nav_home -> Unit
+                    R.id.ic_bot_nav_rules -> Unit
+                    R.id.ic_bot_nav_profile -> Unit
                 }
             }
         }


### PR DESCRIPTION
## 작업 개요

바텀 네비게이션 메뉴를 중복 클릭했을 때 프래그먼트가 재 호출 되는 문제 때문

## 작업 설명

**setOnItemReselectedListener** 함수 사용해서 아이템을 재 선택했을 때 효과를 없앴다

## 궁금한점

## 어려웠던점
